### PR TITLE
NeonDecoder: implemented support for unicode surrogate pairs

### DIFF
--- a/tests/Neon/Decoder.errors.phpt
+++ b/tests/Neon/Decoder.errors.phpt
@@ -17,6 +17,11 @@ Assert::exception(function() {
 
 
 Assert::exception(function() {
+	Neon::decode('"\uD801"');
+}, 'Nette\Neon\Exception', "Invalid UTF-8 (lone surrogate) \\uD801 on line 1, column 1." );
+
+
+Assert::exception(function() {
 	Neon::decode("- Dave,\n- Rimmer,\n- Kryten,\n");
 }, 'Nette\Neon\Exception', "Unexpected ',' on line 1, column 7." );
 

--- a/tests/Neon/Decoder.scalar.phpt
+++ b/tests/Neon/Decoder.scalar.phpt
@@ -25,6 +25,9 @@ Assert::same( 'the"string', Neon::decode('the"string #literal') );
 Assert::same( "the'string #literal", Neon::decode('"the\'string #literal"') );
 Assert::same( 'the"string #literal', Neon::decode("'the\"string #literal'") );
 Assert::same( 'the"string #literal', Neon::decode('"the\\"string #literal"') );
+Assert::same( '@', Neon::decode('"\u0040"') );
+Assert::same( "\xC4\x9B", Neon::decode('"\u011B"') );
+Assert::same( "\xf0\x90\x90\x81", Neon::decode('"\uD801\uDC01"') ); // U+10401 encoded as surrogate pair
 Assert::same( '<literal> <literal>', Neon::decode('<literal> <literal>') );
 Assert::same( "", Neon::decode("''") );
 Assert::same( "", Neon::decode('""') );


### PR DESCRIPTION
Its mostly useless but it is required for compatibility with JSON.
