### PR TITLE
[WIP] Neon::decode should always return valid UTF-8 string

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: php
+php:
+    - 5.3.3
+    - 5.4
+    - 5.5
+    - 5.6
+    - hhvm
+
+matrix:
+    allow_failures:
+        - php: hhvm
+
+script: vendor/bin/tester tests -s -c tests/php-unix.ini
+
+after_failure:
+    # Print *.actual content
+    - for i in $(find tests -name \*.actual); do echo "--- $i"; cat $i; echo; echo; done
+
+before_script:
+    # Install Nette Tester
+    - composer install --no-interaction --dev --prefer-source

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,31 @@
+{
+	"name": "nette/neon",
+	"description": "Nette NEON: parser & generator for Nette Object Notation",
+	"homepage": "http://ne-on.org",
+	"license": ["BSD-3-Clause", "GPL-2.0", "GPL-3.0"],
+	"authors": [
+		{
+			"name": "David Grudl",
+			"homepage": "http://davidgrudl.com"
+		},
+		{
+			"name": "Nette Community",
+			"homepage": "http://nette.org/contributors"
+		}
+	],
+	"require": {
+		"php": ">=5.3.1"
+	},
+	"require-dev": {
+		"nette/tester": "@dev"
+	},
+	"autoload": {
+		"classmap": ["src/"]
+	},
+	"minimum-stability": "dev",
+	"extra": {
+		"branch-alias": {
+			"dev-master": "2.2-dev"
+		}
+	}
+}

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,30 @@
+[NEON](http://ne-on.org): Nette Object Notation
+===============================================
+
+NEON is very similar to YAML.The main difference is that the NEON supports "entities"
+(so can be used e.g. to parse phpDoc annotations) and tab characters for indentation.
+NEON syntax is a little simpler and the parsing is faster.
+
+Example of Neon code:
+
+```
+# my web application config
+
+php:
+	date.timezone: Europe/Prague
+	zlib.output_compression: yes  # use gzip
+
+database:
+	driver: mysql
+	username: root
+	password: beruska92
+
+users:
+	- Dave
+	- Kryten
+	- Rimmer
+```
+
+-----
+
+[![Build Status](https://secure.travis-ci.org/nette/application.png?branch=master)](http://travis-ci.org/nette/application)

--- a/src/Neon/Neon.php
+++ b/src/Neon/Neon.php
@@ -15,7 +15,7 @@ use Nette;
  *
  * @author     David Grudl
  */
-class Neon extends Nette\Object
+class Neon
 {
 	const BLOCK = 1;
 
@@ -43,7 +43,7 @@ class Neon extends Nette\Object
 		}
 
 		if (is_array($var)) {
-			$isList = Arrays::isList($var);
+			$isList = !$var || array_keys($var) === range(0, count($var) - 1);
 			$s = '';
 			if ($options & self::BLOCK) {
 				if (count($var) === 0) {

--- a/src/Neon/NeonDecoder.php
+++ b/src/Neon/NeonDecoder.php
@@ -16,7 +16,7 @@ use Nette;
  * @author     David Grudl
  * @internal
  */
-class NeonDecoder extends Nette\Object
+class NeonDecoder
 {
 	/** @var array */
 	public static $patterns = array(
@@ -73,13 +73,13 @@ class NeonDecoder extends Nette\Object
 		} elseif (substr($input, 0, 3) === "\xEF\xBB\xBF") { // BOM
 			$input = substr($input, 3);
 		}
-		$this->input = $input = str_replace("\r", '', $input);
+		$this->input = str_replace("\r", '', $input);
 
 		$pattern = '~(' . implode(')|(', self::$patterns) . ')~Amix';
-		$this->tokens = Strings::split($input, $pattern, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_OFFSET_CAPTURE);
+		$this->tokens = preg_split($pattern, $this->input, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_OFFSET_CAPTURE | PREG_SPLIT_DELIM_CAPTURE);
 
 		$last = end($this->tokens);
-		if ($this->tokens && !Strings::match($last[0], $pattern)) {
+		if ($this->tokens && !preg_match($pattern, $last[0])) {
 			$this->pos = count($this->tokens) - 1;
 			$this->error();
 		}
@@ -286,7 +286,7 @@ class NeonDecoder extends Nette\Object
 		if (isset($mapping[$sq[1]])) {
 			return $mapping[$sq[1]];
 		} elseif ($sq[1] === 'u' && strlen($sq) === 6) {
-			return Strings::chr(hexdec(substr($sq, 2)));
+			return iconv('UTF-32BE', 'UTF-8//IGNORE', pack('N', hexdec(substr($sq, 2))));
 		} elseif ($sq[1] === 'x' && strlen($sq) === 4) {
 			return chr(hexdec(substr($sq, 2)));
 		} else {
@@ -302,7 +302,7 @@ class NeonDecoder extends Nette\Object
 		$text = substr($this->input, 0, $offset);
 		$line = substr_count($text, "\n") + 1;
 		$col = $offset - strrpos("\n" . $text, "\n") + 1;
-		$token = $last ? str_replace("\n", '<new line>', Strings::truncate($last[0], 40)) : 'end';
+		$token = $last ? str_replace("\n", '<new line>',  substr($last[0], 0, 40)) : 'end';
 		throw new NeonException(str_replace('%s', $token, $message) . " on line $line, column $col.");
 	}
 

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,3 @@
+/*/output
+/test.log
+/tmp

--- a/tests/Neon/Neon.decode.scalar.phpt
+++ b/tests/Neon/Neon.decode.scalar.phpt
@@ -37,3 +37,25 @@ Assert::same( "@x", Neon::decode("@x") );
 Assert::same( "@true", Neon::decode("@true") );
 Assert::same( 'a', Neon::decode('a                                     ') );
 Assert::same( 'a', Neon::decode("\xEF\xBB\xBFa") );
+
+// failing test
+$examples = array(
+    //'Valid ASCII' => "a",
+    //'Valid 2 Octet Sequence' => "\xc3\xb1",
+    'Invalid 2 Octet Sequence' => "\xc3\x28",
+    'Invalid Sequence Identifier' => "\xa0\xa1",
+    //'Valid 3 Octet Sequence' => "\xe2\x82\xa1",
+    'Invalid 3 Octet Sequence (in 2nd Octet)' => "\xe2\x28\xa1",
+    'Invalid 3 Octet Sequence (in 3rd Octet)' => "\xe2\x82\x28",
+    //'Valid 4 Octet Sequence' => "\xf0\x90\x8c\xbc",
+    'Invalid 4 Octet Sequence (in 2nd Octet)' => "\xf0\x28\x8c\xbc",
+    'Invalid 4 Octet Sequence (in 3rd Octet)' => "\xf0\x90\x28\xbc",
+    'Invalid 4 Octet Sequence (in 4th Octet)' => "\xf0\x28\x8c\x28",
+    'Valid 5 Octet Sequence (but not Unicode!)' => "\xf8\xa1\xa1\xa1\xa1",
+    'Valid 6 Octet Sequence (but not Unicode!)' => "\xfc\xa1\xa1\xa1\xa1\xa1",
+);
+
+foreach ($examples as $label => $s) {
+	echo $label . "\n";
+	Assert::same("", Neon::decode('"' . $s . '"'));
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,19 @@
+<?php
+
+// The Nette Tester command-line runner can be
+// invoked through the command: ../vendor/bin/tester .
+
+if (@!include __DIR__ . '/../vendor/autoload.php') {
+	echo 'Install Nette Tester using `composer update --dev`';
+	exit(1);
+}
+
+
+Tester\Environment::setup();
+date_default_timezone_set('Europe/Prague');
+
+
+function test(\Closure $function)
+{
+	$function();
+}

--- a/tests/php-unix.ini
+++ b/tests/php-unix.ini
@@ -1,0 +1,6 @@
+[PHP]
+;extension_dir = "./ext"
+extension=json.so
+
+[Zend]
+;zend_extension="./ext/zend_extension"

--- a/tests/php-win.ini
+++ b/tests/php-win.ini
@@ -1,0 +1,5 @@
+[PHP]
+extension_dir = "./ext"
+
+[Zend]
+;zend_extension="./ext/php_xdebug-2.0.5-5.3-vc6.dll"


### PR DESCRIPTION
Would you prefer exception or silently ignoring? I would prefer exception.

Another question: what about https://en.wikipedia.org/wiki/UTF-8#Invalid_code_points or https://en.wikipedia.org/wiki/UTF-8#Overlong_encodings?
