### PR TITLE
Changed namespace to Nette\Neon (WIP)

### DIFF
--- a/src/Neon/Decoder.php
+++ b/src/Neon/Decoder.php
@@ -5,7 +5,7 @@
  * Copyright (c) 2004 David Grudl (http://davidgrudl.com)
  */
 
-namespace Nette\Utils;
+namespace Nette\Neon;
 
 use Nette;
 
@@ -16,7 +16,7 @@ use Nette;
  * @author     David Grudl
  * @internal
  */
-class NeonDecoder
+class Decoder
 {
 	/** @var array */
 	public static $patterns = array(
@@ -147,7 +147,7 @@ class NeonDecoder
 						$this->error();
 					}
 					$n++;
-					$entity = new NeonEntity;
+					$entity = new Entity;
 					$entity->value = $value;
 					$entity->attributes = $this->parse(NULL, array());
 					$value = $entity;
@@ -303,7 +303,7 @@ class NeonDecoder
 		$line = substr_count($text, "\n") + 1;
 		$col = $offset - strrpos("\n" . $text, "\n") + 1;
 		$token = $last ? str_replace("\n", '<new line>', substr($last[0], 0, 40)) : 'end';
-		throw new NeonException(str_replace('%s', $token, $message) . " on line $line, column $col.");
+		throw new Exception(str_replace('%s', $token, $message) . " on line $line, column $col.");
 	}
 
 }

--- a/src/Neon/Entity.php
+++ b/src/Neon/Entity.php
@@ -5,7 +5,7 @@
  * Copyright (c) 2004 David Grudl (http://davidgrudl.com)
  */
 
-namespace Nette\Utils;
+namespace Nette\Neon;
 
 use Nette;
 
@@ -13,7 +13,7 @@ use Nette;
 /**
  * Representation of 'foo(bar=1)' literal
  */
-class NeonEntity extends \stdClass
+class Entity extends \stdClass
 {
 	public $value;
 	public $attributes;

--- a/src/Neon/Exception.php
+++ b/src/Neon/Exception.php
@@ -5,14 +5,14 @@
  * Copyright (c) 2004 David Grudl (http://davidgrudl.com)
  */
 
-namespace Nette\Utils;
+namespace Nette\Neon;
 
 use Nette;
 
 
 /**
- * The exception that indicates error of NEON decoding.
+ * The exception that indicates error of NEON processing.
  */
-class NeonException extends \Exception
+class Exception extends \Exception
 {
 }

--- a/src/Neon/Neon.php
+++ b/src/Neon/Neon.php
@@ -5,7 +5,7 @@
  * Copyright (c) 2004 David Grudl (http://davidgrudl.com)
  */
 
-namespace Nette\Utils;
+namespace Nette\Neon;
 
 use Nette;
 
@@ -31,7 +31,7 @@ class Neon
 		if ($var instanceof \DateTime) {
 			return $var->format('Y-m-d H:i:s O');
 
-		} elseif ($var instanceof NeonEntity) {
+		} elseif ($var instanceof Entity) {
 			return self::encode($var->value) . '(' . substr(self::encode($var->attributes), 1, -1) . ')';
 		}
 
@@ -67,7 +67,7 @@ class Neon
 
 		} elseif (is_string($var) && !is_numeric($var)
 			&& !preg_match('~[\x00-\x1F]|^\d{4}|^(true|false|yes|no|on|off|null)\z~i', $var)
-			&& preg_match('~^' . NeonDecoder::$patterns[1] . '\z~x', $var) // 1 = literals
+			&& preg_match('~^' . Decoder::$patterns[1] . '\z~x', $var) // 1 = literals
 		) {
 			return $var;
 
@@ -88,7 +88,7 @@ class Neon
 	 */
 	public static function decode($input)
 	{
-		$decoder = new NeonDecoder;
+		$decoder = new Decoder;
 		return $decoder->decode($input);
 	}
 

--- a/tests/Neon/Neon.decode.array.phpt
+++ b/tests/Neon/Neon.decode.array.phpt
@@ -1,12 +1,12 @@
 <?php
 
 /**
- * Test: Nette\Utils\Neon::decode block hash and array.
+ * Test: Nette\Neon\Neon::decode block hash and array.
  *
  * @author     David Grudl
  */
 
-use Nette\Utils\Neon,
+use Nette\Neon\Neon,
 	Tester\Assert;
 
 

--- a/tests/Neon/Neon.decode.errors.phpt
+++ b/tests/Neon/Neon.decode.errors.phpt
@@ -1,12 +1,12 @@
 <?php
 
 /**
- * Test: Nette\Utils\Neon::decode errors.
+ * Test: Nette\Neon\Neon::decode errors.
  *
  * @author     David Grudl
  */
 
-use Nette\Utils\Neon,
+use Nette\Neon\Neon,
 	Tester\Assert;
 
 
@@ -15,39 +15,39 @@ require __DIR__ . '/../bootstrap.php';
 
 Assert::exception(function() {
 	Neon::decode("Hello\nWorld");
-}, 'Nette\Utils\NeonException', "Unexpected 'World' on line 2, column 1." );
+}, 'Nette\Neon\Exception', "Unexpected 'World' on line 2, column 1." );
 
 
 Assert::exception(function() {
 	Neon::decode("- Dave,\n- Rimmer,\n- Kryten,\n");
-}, 'Nette\Utils\NeonException', "Unexpected ',' on line 1, column 7." );
+}, 'Nette\Neon\Exception', "Unexpected ',' on line 1, column 7." );
 
 
 Assert::exception(function() {
 	Neon::decode("- first: Dave\n last: Lister\n gender: male\n");
-}, 'Nette\Utils\NeonException', "Unexpected ':' on line 1, column 8." );
+}, 'Nette\Neon\Exception', "Unexpected ':' on line 1, column 8." );
 
 
 Assert::exception(function() {
 	Neon::decode(" - first\n - second");
-}, 'Nette\Utils\NeonException', "Unexpected indentation. on line 2, column 2." );
+}, 'Nette\Neon\Exception', "Unexpected indentation. on line 2, column 2." );
 
 
 Assert::exception(function() {
 	Neon::decode('item [a, b]');
-}, 'Nette\Utils\NeonException', "Unexpected ',' on line 1, column 8." );
+}, 'Nette\Neon\Exception', "Unexpected ',' on line 1, column 8." );
 
 
 Assert::exception(function() {
 	Neon::decode('{,}');
-}, 'Nette\Utils\NeonException', "Unexpected ',' on line 1, column 2." );
+}, 'Nette\Neon\Exception', "Unexpected ',' on line 1, column 2." );
 
 
 Assert::exception(function() {
 	Neon::decode('{a, ,}');
-}, 'Nette\Utils\NeonException', "Unexpected ',' on line 1, column 5." );
+}, 'Nette\Neon\Exception', "Unexpected ',' on line 1, column 5." );
 
 
 Assert::exception(function() {
 	Neon::decode('"');
-}, 'Nette\Utils\NeonException', "Unexpected '\"' on line 1, column 1." );
+}, 'Nette\Neon\Exception', "Unexpected '\"' on line 1, column 1." );

--- a/tests/Neon/Neon.decode.inline.array.phpt
+++ b/tests/Neon/Neon.decode.inline.array.phpt
@@ -1,12 +1,12 @@
 <?php
 
 /**
- * Test: Nette\Utils\Neon::decode inline hash and array.
+ * Test: Nette\Neon\Neon::decode inline hash and array.
  *
  * @author     David Grudl
  */
 
-use Nette\Utils\Neon,
+use Nette\Neon\Neon,
 	Tester\Assert;
 
 
@@ -53,7 +53,7 @@ Assert::same( array(
 ), Neon::decode("{a,\nb\nc: 1,\nd: 1,\n\ne: 1\nf:\n}") );
 
 
-Assert::type( 'Nette\Utils\NeonEntity', Neon::decode('@item(a, b)') );
+Assert::type( 'Nette\Neon\Entity', Neon::decode('@item(a, b)') );
 
 
 Assert::same( array(

--- a/tests/Neon/Neon.decode.scalar.phpt
+++ b/tests/Neon/Neon.decode.scalar.phpt
@@ -1,12 +1,12 @@
 <?php
 
 /**
- * Test: Nette\Utils\Neon::decode simple values.
+ * Test: Nette\Neon\Neon::decode simple values.
  *
  * @author     David Grudl
  */
 
-use Nette\Utils\Neon,
+use Nette\Neon\Neon,
 	Tester\Assert;
 
 

--- a/tests/Neon/Neon.encode.phpt
+++ b/tests/Neon/Neon.encode.phpt
@@ -1,12 +1,12 @@
 <?php
 
 /**
- * Test: Nette\Utils\Neon::encode.
+ * Test: Nette\Neon\Neon::encode.
  *
  * @author     David Grudl
  */
 
-use Nette\Utils\Neon,
+use Nette\Neon\Neon,
 	Tester\Assert;
 
 


### PR DESCRIPTION
Since Neon contains more than one class, it should be moved to it's own namespace.
