### PR TITLE
Decoder: array-after-key syntax allows only array, not scalars

### DIFF
--- a/src/Neon/Decoder.php
+++ b/src/Neon/Decoder.php
@@ -223,7 +223,7 @@ class Decoder
 
 						} elseif ($hasKey) {
 							$this->addValue($result, $key, $hasValue ? $value : NULL);
-							if ($key !== NULL && !$hasValue && $newIndent === $indent) {
+							if ($key !== NULL && !$hasValue && $newIndent === $indent && isset($tokens[$n + 1]) && $tokens[$n + 1][0] === '-') {
 								$result = & $result[$key];
 							}
 							$hasKey = $hasValue = FALSE;

--- a/tests/Neon/Decoder.errors.phpt
+++ b/tests/Neon/Decoder.errors.phpt
@@ -90,3 +90,11 @@ Assert::exception(function() {
 Assert::exception(function() {
 	Neon::decode('- x: y:');
 }, 'Nette\Neon\Exception', "Unexpected ':' on line 1, column 7." );
+
+
+Assert::exception(function () {
+	Neon::decode('
+foo:
+bar
+');
+}, 'Nette\Neon\Exception', "Unexpected '<new line>' on line 3, column 4.");


### PR DESCRIPTION
Fixes #14
BC break: yes, but this syntax was just a mistake :)
