### PR TITLE
handle invalid utf8 without fatal error

### DIFF
--- a/src/Neon/Encoder.php
+++ b/src/Neon/Encoder.php
@@ -80,7 +80,7 @@ final class Encoder
 			$json = json_encode($var, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
 			if ($json === false) {
 				// explicitly throw exception, instead of returning 'false' which would hard-error because of strict-types
-				throw new Exception('Unable to json_encode() value:'. $var);
+				throw new Exception('Unable to json_encode() value:' . $var);
 			}
 			return $json;
 		}

--- a/src/Neon/Encoder.php
+++ b/src/Neon/Encoder.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Nette\Neon;
 
+use LogicException;
 
 /**
  * Simple generator for Nette Object Notation.
@@ -78,7 +79,12 @@ final class Encoder
 			return strpos($var, '.') === false ? $var . '.0' : $var;
 
 		} else {
-			return json_encode($var, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+			$json = json_encode($var, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+			if ($json === false) {
+				// explicitly throw exception, instead of returning 'false' which would hard-error because of strict-types
+				throw new LogicException('Unable to json_encode() value:'. $var);
+			}
+			return $json;
 		}
 	}
 }

--- a/src/Neon/Encoder.php
+++ b/src/Neon/Encoder.php
@@ -9,8 +9,6 @@ declare(strict_types=1);
 
 namespace Nette\Neon;
 
-use LogicException;
-
 /**
  * Simple generator for Nette Object Notation.
  */

--- a/src/Neon/Encoder.php
+++ b/src/Neon/Encoder.php
@@ -82,7 +82,7 @@ final class Encoder
 			$json = json_encode($var, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
 			if ($json === false) {
 				// explicitly throw exception, instead of returning 'false' which would hard-error because of strict-types
-				throw new LogicException('Unable to json_encode() value:'. $var);
+				throw new Exception('Unable to json_encode() value:'. $var);
 			}
 			return $json;
 		}

--- a/tests/Neon/Encoder.phpt
+++ b/tests/Neon/Encoder.phpt
@@ -104,5 +104,6 @@ Assert::same(
 	Neon::encode(new DateTimeImmutable('2016-06-03T19:00:00+02:00'))
 );
 
-// should not throw
-Neon::encode("a invalid utf8 char sequence: \xc2\x82\x28\xfc\xa1\xa1\xa1\xa1\xa1\xe2\x80\x82");
+Assert::exception(function() {
+	Neon::encode("a invalid utf8 char sequence: \xc2\x82\x28\xfc\xa1\xa1\xa1\xa1\xa1\xe2\x80\x82");
+}, Nette\Neon\Exception::class);

--- a/tests/Neon/Encoder.phpt
+++ b/tests/Neon/Encoder.phpt
@@ -104,6 +104,6 @@ Assert::same(
 	Neon::encode(new DateTimeImmutable('2016-06-03T19:00:00+02:00'))
 );
 
-Assert::exception(function() {
+Assert::exception(function () {
 	Neon::encode("a invalid utf8 char sequence: \xc2\x82\x28\xfc\xa1\xa1\xa1\xa1\xa1\xe2\x80\x82");
 }, Nette\Neon\Exception::class);

--- a/tests/Neon/Encoder.phpt
+++ b/tests/Neon/Encoder.phpt
@@ -103,3 +103,6 @@ Assert::same(
 	'2016-06-03 19:00:00 +0200',
 	Neon::encode(new DateTimeImmutable('2016-06-03T19:00:00+02:00'))
 );
+
+// should not throw
+Neon::encode("a invalid utf8 char sequence: \xc2\x82\x28\xfc\xa1\xa1\xa1\xa1\xa1\xe2\x80\x82");


### PR DESCRIPTION
handle a possible invalid utf8 string which cannot be `json_encode()`'d and throw a `Exception` instead of returning the boolean `false` which will make php hard-error at runtime.

closes https://github.com/nette/neon/issues/46

without this change php would just fatal error with `Nette\Neon\Encoder::encode() must be of the type string, boolean returned` and there is no way to handle this.