### PR TITLE
Encoder: multiline string escaping

### DIFF
--- a/tests/Neon/Encoder.phpt
+++ b/tests/Neon/Encoder.phpt
@@ -44,6 +44,18 @@ Assert::same(
 );
 
 Assert::same(
+	"multi:
+	\"\"\"
+		line string
+			with tabs
+			and \"quotation marks\"
+	\"\"\"",
+	Neon::encode([
+		'multi' => "line string\n\twith tabs\n\tand \"quotation marks\""
+	])
+);
+
+Assert::same(
 	'["[", "]", "{", "}", ":", ": ", "=", "#"]',
 	Neon::encode(['[', ']', '{', '}', ':', ': ', '=', '#'])
 );


### PR DESCRIPTION
New multiline strings encoding works nice, but encoded string readability is not ideal. Could you please add support for tab `	` instead of `\t`?
Also `"` would be nice instead of `\"`

I wrote failing test to demonstrate expected behavior (same as below)

```
multi:
	"""
		line string
			with tabs
			and "quotation marks"
	"""
```

Thank you a lot