### PR TITLE
Encoder - some problematic letters like "è"

### DIFF
--- a/src/Neon/Encoder.php
+++ b/src/Neon/Encoder.php
@@ -67,13 +67,13 @@ final class Encoder
 
 		} elseif (
 			is_string($var)
-			&& !preg_match('~[\x00-\x1F]|^[+-.]?\d|^(true|false|yes|no|on|off|null)$~Di', $var)
+			&& !preg_match('~[\x00-\x1F]|[\x7F-\xFF]|^[+-.]?\d|^(true|false|yes|no|on|off|null)$~Di', $var)
 			&& preg_match('~^' . Decoder::PATTERNS[1] . '$~Dx', $var) // 1 = literals
 		) {
 			return $var;
 
 		} elseif (is_string($var)) {
-			if (!preg_match('~[\x00-\x1F]|^[+-.]?\d|^(true|false|yes|no|on|off|null)$~Di', $var)
+			if (!preg_match('~[\x00-\x1F]|[\x7F-\xFF]|^[+-.]?\d|^(true|false|yes|no|on|off|null)$~Di', $var)
 				&& preg_match('~^' . Decoder::PATTERNS[1] . '$~Dx', $var) // 1 = literals
 			) {
 				return $var;

--- a/src/Neon/Encoder.php
+++ b/src/Neon/Encoder.php
@@ -64,7 +64,7 @@ final class Encoder
 				}
 				return ($isList ? '[' : '{') . substr($s, 0, -2) . ($isList ? ']' : '}');
 			}
-			
+
 		} elseif (is_string($var)) {
 			if (!preg_match('~[\x00-\x1F]|[\x7F-\xFF]|^[+-.]?\d|^(true|false|yes|no|on|off|null)$~Di', $var)
 				&& preg_match('~^' . Decoder::PATTERNS[1] . '$~Dx', $var) // 1 = literals

--- a/tests/Neon/Encoder.phpt
+++ b/tests/Neon/Encoder.phpt
@@ -39,6 +39,11 @@ Assert::same(
 );
 
 Assert::same(
+	"{multi: [\"\"\"\n\tone\n\ttwo\n\tthree\\\\ne \"'\t\n\"\"\"]}",
+	Neon::encode(['multi' => ["one\ntwo\nthree\\ne \"'\t"]])
+);
+
+Assert::same(
 	'["[", "]", "{", "}", ":", ": ", "=", "#"]',
 	Neon::encode(['[', ']', '{', '}', ':', ': ', '=', '#'])
 );


### PR DESCRIPTION
- bug fix
- BC break? no (as I know)

I have troubles with some French texts like `Demande non valide. Paramètres erronés.` - nette:neon encode it just like:
```
Demande non valide. Paramètres erronés.
```

But then there was error to read that files. It was about letter `è` So I changed the rules when quotes should be used - `[\x7F-\xFF]` was added. After that texts are encoded with quotes (`"Demande non valide. Paramètres erronés."`) when these letters are in texts and decoding is successful. Maybe not all that letters have to be encoded with quotes - I just choose it as fast solution.