### PR TITLE
Decoder: remove @internal phpdoc

### DIFF
--- a/src/Neon/Decoder.php
+++ b/src/Neon/Decoder.php
@@ -12,7 +12,6 @@ namespace Nette\Neon;
 
 /**
  * Parser for Nette Object Notation.
- * @internal
  */
 final class Decoder
 {


### PR DESCRIPTION
`Encoder` is not marked as `@internal` so neither should imho be `Decoder`.
I prefer using them directly instead of `Neon` class to be slightly more efficient