### PR TITLE
[test] add Neon node re-print tests for list

### DIFF
--- a/tests/Neon/Node.printer.phpt
+++ b/tests/Neon/Node.printer.phpt
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Nette\Neon\Lexer;
+use Nette\Neon\Parser;
+use Tester\Assert;
+
+require __DIR__ . '/../bootstrap.php';
+
+$lexer = new Lexer();
+$fileContents = file_get_contents(__DIR__ . '/fixtures/nested-list.neon');
+$tokens = $lexer->tokenize($fileContents);
+
+$parser = new Parser();
+$node = $parser->parse($tokens);
+
+$reprintedNode = $node->toString();
+
+Assert::matchFile(
+	__DIR__ . '/fixtures/nested-list.neon',
+	$reprintedNode
+);

--- a/tests/Neon/Node.printer.phpt
+++ b/tests/Neon/Node.printer.phpt
@@ -17,7 +17,14 @@ $node = $parser->parse($tokens);
 
 $reprintedNode = $node->toString();
 
+// this is current incorrect behavior
+Assert::matchFile(
+	__DIR__ . '/fixtures/nested-list-actualy-reprint.neon',
+	$reprintedNode
+);
+
 Assert::matchFile(
 	__DIR__ . '/fixtures/nested-list.neon',
 	$reprintedNode
 );
+

--- a/tests/Neon/fixtures/nested-list-actualy-reprint.neon
+++ b/tests/Neon/fixtures/nested-list-actualy-reprint.neon
@@ -1,3 +1,2 @@
 services:
-first:
-    class: SomeClass
+key: value

--- a/tests/Neon/fixtures/nested-list-actualy-reprint.neon
+++ b/tests/Neon/fixtures/nested-list-actualy-reprint.neon
@@ -1,0 +1,3 @@
+services:
+first:
+    class: SomeClass

--- a/tests/Neon/fixtures/nested-list.neon
+++ b/tests/Neon/fixtures/nested-list.neon
@@ -1,0 +1,3 @@
+services:
+    first:
+        class: SomeClass

--- a/tests/Neon/fixtures/nested-list.neon
+++ b/tests/Neon/fixtures/nested-list.neon
@@ -1,3 +1,2 @@
 services:
-    first:
-        class: SomeClass
+    key: value


### PR DESCRIPTION
Hi, thanks for new AST feature for NEON :).
This will make Nette upgrades even easier and allows to analyse configs with static analysis :+1: 

I tried prototype in automated upgrade and 3.3.0 worked quite well.
Since 3.3.1, there is a bug in simple list reprint.:

```diff
 services:
-    key: value
+key: value
```

Looks like first nested line is removed. I looked into [diff of 3.3.0 and 3.3.1](https://github.com/nette/neon/compare/v3.3.0...v3.3.1), but could not find anything uesful.

But maybe I'm using printer it wrong. How can I help to fix this?

Thank you :+1: 