### PR TITLE
Fix mixed indents in block strings

### DIFF
--- a/tests/Neon/Encoder.phpt
+++ b/tests/Neon/Encoder.phpt
@@ -180,3 +180,8 @@ Assert::same(
 	"\"\"\"\n\tspecial\\r\n\tchars\n\"\"\"",
 	Neon::encode("special\r\nchars", true),
 );
+
+Assert::same(
+	"inner:\n    msg: '''\n        string\n        with newline\n    '''\n\n",
+	Neon::encode(['inner' => ['msg' => "string\nwith newline"]], true, '    '),
+);


### PR DESCRIPTION
- bug fix
- BC break? no

---------

- When using custom indents (spaces) and block mode, inner part of block strings were always indented with tab. 
- This showed up in our git-based whitespace check in pre-commit (`git diff-index --check --cached HEAD -- $FILES`) as `space before tab in indent` error. 
- The real usecase is [PHPStan baseline of deprecated usages](https://github.com/phpstan/phpstan-deprecation-rules/tree/2.0.x) where [newline is very often](https://github.com/phpstan/phpstan-deprecation-rules/blob/adf5e2396b0937cdda3dac97f7f68116e61a79b9/src/Rules/Deprecations/CallToDeprecatedMethodRule.php#L75).

Before:
```
inner:
    msg: '''
    	string
    	with newline
    '''
```

After this fix:
```
inner:
    msg: '''
        string
        with newline
    '''
```
